### PR TITLE
Fixed bug rendering extra requirements.

### DIFF
--- a/poetry_setup/templates/setup.py.j2
+++ b/poetry_setup/templates/setup.py.j2
@@ -96,7 +96,7 @@ setup(
         {{ extra|pprint}}: {% if dep %}[
             {% for sub in dep %}
             '{{sub.pretty_name}}{{sub.constraint}}',
-            {%endfor %}
+            {% endfor %}
         ]{% else %}[]{% endif %},
         {% endfor %}
     {{ '},' }}

--- a/poetry_setup/templates/setup.py.j2
+++ b/poetry_setup/templates/setup.py.j2
@@ -91,7 +91,15 @@ setup(
     ],  # Optional
 
     {% if package.extras %}
-        extras_require={{ package.extras|pprint }},
+    extras_require={
+        {% for extra, dep in package.extras.items() %}
+        {{ extra|pprint}}: {% if dep %}[
+            {% for sub in dep %}
+            '{{sub.pretty_name}}{{sub.constraint}}',
+            {%endfor %}
+        ]{% else %}[]{% endif %},
+        {% endfor %}
+    {{ '},' }}
     {% endif %}
 
     # https://stackoverflow.com/a/16576850


### PR DESCRIPTION
@orsinium Nice work, any chance you could reviewed this change. 

I'd also like to add support for using custom templates. Which removes some boilerplate that not everyone likes to add. Thanks

```bash
Traceback (most recent call last):
...
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 148
    extras_require={'deploy': [<Dependency bump2version (^0.5.11)>,
```